### PR TITLE
Change touch() to file_put_contents()

### DIFF
--- a/src/AutoUpdate.php
+++ b/src/AutoUpdate.php
@@ -756,7 +756,8 @@ class AutoUpdate
                     return false;
                 }
             } else {
-                if (!touch($absoluteFilename)) {
+                // touch will fail if PHP is not the owner of the file, and file_put_contents is faster than touch.
+                if (!file_put_contents($absoluteFilename)) {
                     $this->_log->addError(sprintf('[SIMULATE] The file "%s" could not be created!', $absoluteFilename));
                     zip_close($zip);
 


### PR DESCRIPTION
Touch will fail if PHP is not the owner (or if it does not have the correct permissions), whereas file_put_contents would be successful in these circumstances. Plus, in tests that I've seen online, it's shown that file_put_contents is faster than touch() (by up to x2 the speed).