### PR TITLE
Introduce PSR 3 for logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "php": ">=7.2.0",
         "desarrolla2/cache": "^3.0",
         "monolog/monolog": "^2.1",
-        "composer/semver": "^3.0"
+        "composer/semver": "^3.0",
+        "psr/log": "3.0.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "desarrolla2/cache": "^3.0",
         "monolog/monolog": "^2.1",
         "composer/semver": "^3.0",
-        "psr/log": "3.0.0"
+        "psr/log": "1.1.4"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",

--- a/example/client/update/index.php
+++ b/example/client/update/index.php
@@ -9,9 +9,12 @@ $update->setCurrentVersion('0.1.0');
 // Replace with your server update directory
 $update->setUpdateUrl('http://127.0.0.1:8090/example/server');
 
-// Log handler and cache are optional
-$update->addLogHandler(new Monolog\Handler\StreamHandler(__DIR__ . '/update.log'));
+// Custom logger (optional)
+$logger = new \Monolog\Logger("default");
+$logger->pushHandler(new Monolog\Handler\StreamHandler(__DIR__ . '/update.log'));
+$update->setLogger($logger);
 
+// Cache (optional but recommended)
 $cache = new Desarrolla2\Cache\File(__DIR__ . '/cache');
 $update->setCache($cache, 3600);
 

--- a/src/AutoUpdate.php
+++ b/src/AutoUpdate.php
@@ -373,6 +373,7 @@ class AutoUpdate {
      *
      * @param HandlerInterface $handler See https://github.com/Seldaek/monolog
      * @return AutoUpdate
+     * @deprecated Please inject you own logger instance via {@link AutoUpdate::setLogger()}
      */
     public function addLogHandler(HandlerInterface $handler): AutoUpdate
     {

--- a/src/AutoUpdate.php
+++ b/src/AutoUpdate.php
@@ -9,7 +9,6 @@ use ZipArchive;
 use Composer\Semver\Comparator;
 use Desarrolla2\Cache\CacheInterface;
 use Desarrolla2\Cache\NotCache;
-use Monolog\Handler\HandlerInterface;
 use Monolog\Logger;
 use Monolog\Handler\NullHandler;
 use Psr\Log\LoggerInterface;
@@ -365,29 +364,7 @@ class AutoUpdate {
     }
 
     /**
-     * Add a new logging handler.
-     *
-     * Warning: If you use {@link AutoUpdate::setLogger()} together with this function, the handler will be added to
-     * the given logger interface. You should probably only use either {@link AutoUpdate::addLogHandler()} or
-     * {@link AutoUpdate::setLogger()} but not both!
-     *
-     * @param HandlerInterface $handler See https://github.com/Seldaek/monolog
-     * @return AutoUpdate
-     * @deprecated Please inject you own logger instance via {@link AutoUpdate::setLogger()}
-     */
-    public function addLogHandler(HandlerInterface $handler): AutoUpdate
-    {
-        $this->log->pushHandler($handler);
-
-        return $this;
-    }
-
-    /**
      * Replace the logger internally used by the given logger instance.
-     *
-     * Using this method overwrites any other logger defined via {@link AutoUpdate::addLogHandler()}.
-     *
-     * Warning: You should probably only use either {@link AutoUpdate::addLogHandler()} or {@link AutoUpdate::setLogger()} but not both!
      *
      * @param LoggerInterface $logger
      * @return AutoUpdate

--- a/src/AutoUpdate.php
+++ b/src/AutoUpdate.php
@@ -12,6 +12,7 @@ use Desarrolla2\Cache\NotCache;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Logger;
 use Monolog\Handler\NullHandler;
+use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\InvalidArgumentException;
 use VisualAppeal\Exceptions\DownloadException;
 use VisualAppeal\Exceptions\ParserException;
@@ -44,7 +45,7 @@ class AutoUpdate {
     /**
      * Logger instance.
      *
-     * @var Logger
+     * @var LoggerInterface
      */
     private $log;
 

--- a/src/AutoUpdate.php
+++ b/src/AutoUpdate.php
@@ -367,12 +367,33 @@ class AutoUpdate {
     /**
      * Add a new logging handler.
      *
+     * Warning: If you use {@link AutoUpdate::setLogger()} together with this function, the handler will be added to
+     * the given logger interface. You should probably only use either {@link AutoUpdate::addLogHandler()} or
+     * {@link AutoUpdate::setLogger()} but not both!
+     *
      * @param HandlerInterface $handler See https://github.com/Seldaek/monolog
      * @return AutoUpdate
      */
     public function addLogHandler(HandlerInterface $handler): AutoUpdate
     {
         $this->log->pushHandler($handler);
+
+        return $this;
+    }
+
+    /**
+     * Replace the logger internally used by the given logger instance.
+     *
+     * Using this method overwrites any other logger defined via {@link AutoUpdate::addLogHandler()}.
+     *
+     * Warning: You should probably only use either {@link AutoUpdate::addLogHandler()} or {@link AutoUpdate::setLogger()} but not both!
+     *
+     * @param LoggerInterface $logger
+     * @return AutoUpdate
+     */
+    public function setLogger(LoggerInterface $logger): AutoUpdate
+    {
+        $this->log = $logger;
 
         return $this;
     }

--- a/src/AutoUpdate.php
+++ b/src/AutoUpdate.php
@@ -10,7 +10,6 @@ use Composer\Semver\Comparator;
 use Desarrolla2\Cache\CacheInterface;
 use Desarrolla2\Cache\NotCache;
 use Monolog\Logger;
-use Monolog\Handler\NullHandler;
 use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\InvalidArgumentException;
 use VisualAppeal\Exceptions\DownloadException;
@@ -199,7 +198,6 @@ class AutoUpdate {
     {
         // Init logger
         $this->log = new Logger('auto-update');
-        $this->log->pushHandler(new NullHandler());
 
         $this->setTempDir($tempDir ?? (__DIR__ . DIRECTORY_SEPARATOR . 'temp' . DIRECTORY_SEPARATOR));
         $this->setInstallDir($installDir ?? (__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR));

--- a/tests/AutoUpdateTest.php
+++ b/tests/AutoUpdateTest.php
@@ -25,7 +25,9 @@ class AutoUpdateTest extends TestCase
         $this->_update = new AutoUpdate(__DIR__ . DIRECTORY_SEPARATOR . 'temp', __DIR__ . DIRECTORY_SEPARATOR . 'install');
         $this->_update->setCurrentVersion('0.1.0');
         $this->_update->setUpdateUrl(__DIR__ . DIRECTORY_SEPARATOR . 'fixtures');
-        $this->_update->addLogHandler(new Monolog\Handler\StreamHandler(__DIR__ . DIRECTORY_SEPARATOR . 'temp' . DIRECTORY_SEPARATOR . 'update.log'));
+        $logger = new Monolog\Logger("default");
+        $logger->pushHandler(new Monolog\Handler\StreamHandler(__DIR__ . DIRECTORY_SEPARATOR . 'temp' . DIRECTORY_SEPARATOR . 'update.log'));
+        $this->_update->setLogger($logger);
     }
 
     /**


### PR DESCRIPTION
This PR will replace the `Monolog\Handler\HandlerInterface` usage with `Psr\Log\LoggerInterface` to allow library users more flexibility when choosing a logging solution.

This PR addresses: #52 