### PR TITLE
Update index.php

### DIFF
--- a/example/client/update/index.php
+++ b/example/client/update/index.php
@@ -69,7 +69,7 @@ if ($update->newVersionAvailable()) {
     } else {
         echo 'Update simulation failed: ' . $result . '!<br>';
 
-        if ($result = AutoUpdate::ERROR_SIMULATE) {
+        if ($result == AutoUpdate::ERROR_SIMULATE) {
             echo '<pre>';
             var_dump($update->getSimulationResults());
             echo '</pre>';


### PR DESCRIPTION
If you write if ($result = AutoUpdate::ERROR_SIMULATE), then assign the value of AutoUpdate::ERROR_SIMULATE to the variable $result and then check if this value is true. This is probably not what you want. If you write if ($result == AutoUpdate::ERROR_SIMULATE), then compare the value of $result with the value of AutoUpdate::ERROR_SIMULATE and then check if these values are the same. This is probably what you want.