### PR TITLE
Remove specific cache implementation dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         "ext-json": "*",
         "ext-zip": "*",
         "composer/semver": "^3.0",
-        "desarrolla2/cache": "^3.0",
         "monolog/monolog": "^2.1",
-        "psr/log": "^1.0|^2.0|^3.0"
+        "psr/log": "^1.0|^2.0|^3.0",
+        "psr/simple-cache": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",


### PR DESCRIPTION
The `desarrolla2/cache` package has a dependency on an outdated version of `psr/simple-cache`, which blocks other upgrades. This PR refactors towards just using the SimpleCache Interface and removes the implementation package.

Once the PR has been merged, this may warrant a **major version bump**, as it removes a package that users may rely on (The cache package), which would be triggered by a simple `composer update`.

To prevent multiple big version changes, I will prepare additional PRs for removing Monolog in favour of using only the `LoggerInterface` in `psr/log`, as well as a PHP 8 upgrade. Once done, I will ask for a version 2.0 tag