### PR TITLE
Upgrade to PHP 8 and refactor to PSR Interfaces

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
 
     name: PHPUnit ${{ matrix.php-versions }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 *.cache
 composer.lock
+
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
         "ext-json": "*",
         "ext-zip": "*",
         "composer/semver": "^3.0",
-        "monolog/monolog": "^2.1",
         "psr/log": "^1.0|^2.0|^3.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
-        "roave/security-advisories": "dev-master",
-        "phpunit/phpunit": "^9.5"
+        "monolog/monolog": "^3.9",
+        "phpunit/phpunit": "^9.5",
+        "roave/security-advisories": "dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "scripts": {
-        "test": "phpunit -c tests/UnitTests.xml"
+        "test": "phpunit"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-zip": "*",

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         "ext-json": "*",
         "ext-zip": "*",
         "composer/semver": "^3.0",
-        "desarrolla2/cache": "^3.0",
         "monolog/monolog": "^2.1",
-        "psr/log": "^1.0|^2.0|^3.0"
+        "psr/log": "^1.0|^2.0|^3.0",
+        "psr/simple-cache": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",

--- a/example/client/update/index.php
+++ b/example/client/update/index.php
@@ -28,9 +28,7 @@ if ($update->newVersionAvailable()) {
     echo 'New Version: ' . $update->getLatestVersion() . '<br>';
     echo 'Installing Updates: <br>';
     echo '<pre>';
-    var_dump(array_map(function ($version) {
-        return (string) $version;
-    }, $update->getVersionsToUpdate()));
+    var_dump(array_map(fn($version) => (string) $version, $update->getVersionsToUpdate()));
     echo '</pre>';
 
     // Optional - empty log file

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+              processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/src/AutoUpdate.php
+++ b/src/AutoUpdate.php
@@ -20,136 +20,102 @@ use VisualAppeal\Exceptions\ParserException;
 class AutoUpdate {
     /**
      * The latest version.
-     *
-     * @var string
      */
-    private $latestVersion;
+    private ?string $latestVersion;
 
     /**
      * Updates not yet installed.
-     *
-     * @var array
      */
-    private $updates;
+    private array $updates;
 
     /**
      * Cache for update requests.
-     *
-     * @var CacheInterface|null
      */
-    private $cache = null;
+    private ?CacheInterface $cache = null;
 
     /**
      * Logger instance.
-     *
-     * @var LoggerInterface
      */
-    private $log;
+    private LoggerInterface $log;
 
     /**
      * Result of simulated installation.
      *
      * @var array
      */
-    private $simulationResults = array();
+    private array $simulationResults = array();
 
     /**
      * Temporary download directory.
-     *
-     * @var string
      */
-    private $tempDir = '';
+    private string $tempDir = '';
 
     /**
      * Install directory.
-     *
-     * @var string
      */
-    private $installDir = '';
+    private string $installDir = '';
 
     /**
      * Update branch.
-     *
-     * @var string
      */
-    private $branch = '';
+    private string $branch = '';
 
     /**
      * Username authentication
-     *
-     * @var string
      */
-    private $username = '';
+    private string $username = '';
 
     /**
      * Password authentication
-     *
-     * @var string
      */
-    private $password = '';
+    private string $password = '';
 
-    /*
+    /**
      * Callbacks to be called when each update is finished
-     *
-     * @var array
      */
-    private $onEachUpdateFinishCallbacks = [];
+    private array $onEachUpdateFinishCallbacks = [];
 
-    /*
+    /**
      * Callbacks to be called when all updates are finished
-     *
-     * @var array
      */
-    private $onAllUpdateFinishCallbacks = [];
+    private array $onAllUpdateFinishCallbacks = [];
 
     /**
      * If curl should verify the host certificate.
-     *
-     * @var bool
      */
-    private $sslVerifyHost = true;
+    private bool $sslVerifyHost = true;
 
     /**
      * Url to the update folder on the server.
-     *
-     * @var string
      */
-    protected $updateUrl = 'https://example.com/updates/';
+    protected string $updateUrl = 'https://example.com/updates/';
 
     /**
      * Version filename on the server.
-     *
-     * @var string
      */
-    protected $updateFile = 'update.json';
+    protected string $updateFile = 'update.json';
 
     /**
      * Current version.
-     *
-     * @var string
      */
-    protected $currentVersion;
+    protected string $currentVersion = '';
 
     /**
      * Create new folders with these privileges.
      *
      * @var int
      */
-    public $dirPermissions = 0755;
+    public int $dirPermissions = 0755;
 
     /**
      * Update script filename.
-     *
-     * @var string
      */
-    public $updateScriptName = '_upgrade.php';
+    public string $updateScriptName = '_upgrade.php';
 
     /**
      * How long the cache should be valid (in seconds).
-     *
-     * @var int
      */
-    protected $cacheTtl = 3600;
+    protected int $cacheTtl = 3600;
 
     /**
      * No update available.
@@ -285,11 +251,8 @@ class AutoUpdate {
 
     /**
      * Set the update branch.
-     *
-     * @param string branch
-     * @return AutoUpdate
      */
-    public function setBranch($branch): AutoUpdate
+    public function setBranch(string $branch): AutoUpdate
     {
         $this->branch = $branch;
 
@@ -298,10 +261,6 @@ class AutoUpdate {
 
     /**
      * Set the cache component.
-     *
-     * @param CacheInterface $adapter See https://github.com/desarrolla2/Cache
-     * @param int $ttl
-     * @return AutoUpdate
      */
     public function setCache(CacheInterface $adapter, int $ttl): AutoUpdate
     {
@@ -313,9 +272,6 @@ class AutoUpdate {
 
     /**
      * Set the version of the current installed software.
-     *
-     * @param string $currentVersion
-     * @return AutoUpdate
      */
     public function setCurrentVersion(string $currentVersion): AutoUpdate
     {
@@ -326,10 +282,6 @@ class AutoUpdate {
 
     /**
      * Set username and password for basic authentication.
-     *
-     * @param string $username
-     * @param string $password
-     * @return AutoUpdate
      */
     public function setBasicAuth(string $username, string $password): AutoUpdate
     {
@@ -437,7 +389,7 @@ class AutoUpdate {
      * @throws InvalidArgumentException
      * @throws ParserException
      */
-    public function checkUpdate(int $timeout = 10)
+    public function checkUpdate(int $timeout = 10): bool|int
     {
         $this->log->notice('Checking for a new update...');
 
@@ -497,7 +449,7 @@ class AutoUpdate {
 
                     break;
                 case 'json':
-                    $versions = (array) json_decode($update, false);
+                    $versions = json_decode($update, true);
                     if (!is_array($versions)) {
                         $this->log->error('Unable to parse json update file!');
 
@@ -586,7 +538,7 @@ class AutoUpdate {
      * @param int $timeout
      * @return string|false
      */
-    protected function downloadCurl(string $url, int $timeout = 10)
+    protected function downloadCurl(string $url, int $timeout = 10): bool|string
     {
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, $url);
@@ -857,7 +809,7 @@ class AutoUpdate {
      * @throws ParserException
      * @throws InvalidArgumentException
      */
-    public function update(bool $simulateInstall = true, bool $deleteDownload = true)
+    public function update(bool $simulateInstall = true, bool $deleteDownload = true): bool|int
     {
         $this->log->info('Trying to perform update');
 

--- a/src/AutoUpdate.php
+++ b/src/AutoUpdate.php
@@ -20,7 +20,7 @@ class AutoUpdate {
     /**
      * The latest version.
      */
-    private ?string $latestVersion;
+    private string $latestVersion;
 
     /**
      * Updates not yet installed.
@@ -534,7 +534,7 @@ class AutoUpdate {
     {
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, $url);
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $this->sslVerifyHost ? 2 : 0);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $this->sslVerifyHost);
         curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5);
@@ -714,9 +714,9 @@ class AutoUpdate {
      * @param string $updateFile Path to the update file
      * @param bool $simulateInstall Check for directory and file permissions instead of installing the update
      * @param string $version
-     * @return bool
+     * @return bool|int
      */
-    protected function install(string $updateFile, bool $simulateInstall, string $version): bool
+    protected function install(string $updateFile, bool $simulateInstall, string $version): bool|int
     {
         $this->log?->notice(sprintf('Trying to install update "%s"', $updateFile));
 
@@ -806,11 +806,11 @@ class AutoUpdate {
         $this->log?->info('Trying to perform update');
 
         // Check for latest version
-        if ($this->latestVersion === null || count($this->updates) === 0) {
+        if (count($this->updates) === 0) {
             $this->checkUpdate();
         }
 
-        if ($this->latestVersion === null || count($this->updates) === 0) {
+        if (count($this->updates) === 0) {
             $this->log?->error('Could not get latest version from server!');
 
             return self::ERROR_VERSION_CHECK;

--- a/src/AutoUpdate.php
+++ b/src/AutoUpdate.php
@@ -43,7 +43,7 @@ class AutoUpdate {
      *
      * @var array
      */
-    private array $simulationResults = array();
+    private array $simulationResults = [];
 
     /**
      * Temporary download directory.
@@ -299,11 +299,11 @@ class AutoUpdate {
     private function useBasicAuth()
     {
         if ($this->username && $this->password) {
-            return stream_context_create(array(
-                'http' => array(
+            return stream_context_create([
+                'http' => [
                     'header' => "Authorization: Basic " . base64_encode("$this->username:$this->password")
-                )
-            ));
+                ]
+            ]);
         }
 
         return null;
@@ -340,9 +340,7 @@ class AutoUpdate {
     public function getVersionsToUpdate(): array
     {
         if (count($this->updates) > 0) {
-            return array_map(static function ($update) {
-                return $update['version'];
-            }, $this->updates);
+            return array_map(static fn($update) => $update['version'], $this->updates);
         }
 
         return [];
@@ -443,9 +441,7 @@ class AutoUpdate {
                         throw new ParserException(sprintf('Could not parse update ini file %s!', $this->updateFile));
                     }
 
-                    $versions = array_map(static function ($block) {
-                        return $block['url'] ?? false;
-                    }, $versions);
+                    $versions = array_map(static fn($block) => $block['url'] ?? false, $versions);
 
                     break;
                 case 'json':
@@ -757,10 +753,10 @@ class AutoUpdate {
         // Read every file from archive
         for ($i = 0; $i < $zip->numFiles; $i++) {
             $fileStats        = $zip->statIndex($i);
-            $filename         = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $fileStats['name']);
-            $foldername       = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR,
+            $filename         = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $fileStats['name']);
+            $foldername       = str_replace(['/', '\\'], DIRECTORY_SEPARATOR,
                 $this->installDir . dirname($filename));
-            $absoluteFilename = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $this->installDir . $filename);
+            $absoluteFilename = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $this->installDir . $filename);
             $this->log->debug(sprintf('Updating file "%s"', $filename));
 
             if (!is_dir($foldername) && !mkdir($foldername, $this->dirPermissions, true) && !is_dir($foldername)) {

--- a/tests/AutoUpdateTest.php
+++ b/tests/AutoUpdateTest.php
@@ -8,6 +8,9 @@ use VisualAppeal\AutoUpdate;
 use VisualAppeal\Exceptions\DownloadException;
 use VisualAppeal\Exceptions\ParserException;
 
+/**
+ * @covers \VisualAppeal\AutoUpdate
+ */
 class AutoUpdateTest extends TestCase
 {
     /**

--- a/tests/UnitTests.xml
+++ b/tests/UnitTests.xml
@@ -1,7 +1,0 @@
-<phpunit>
-	<testsuites>
-		<testsuite name="unit">
-			<directory>./</directory>
-		</testsuite>
-	</testsuites>
-</phpunit>


### PR DESCRIPTION
I decided to abandon #58 in favour of one PR for all changes since some of them are linked with PHP 8 null-safe operator.

This change removes the dependency on both `desarrolla2/cache` and `monolog/monolog` and depends on the PSR interfaces instead.
It also bumps the PHP version up to 8.0 and adds types to the properties, as well as function return types.